### PR TITLE
Fix scanner session threading

### DIFF
--- a/Gym-app-ioss/Views/BarcodeScannerView.swift
+++ b/Gym-app-ioss/Views/BarcodeScannerView.swift
@@ -52,11 +52,17 @@ class ScannerViewController: UIViewController {
         previewLayer.frame = view.layer.bounds
         previewLayer.videoGravity = .resizeAspectFill
         view.layer.addSublayer(previewLayer)
-        captureSession.startRunning()
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.captureSession.startRunning()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        if captureSession?.isRunning == true { captureSession.stopRunning() }
+        if captureSession?.isRunning == true {
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                self?.captureSession.stopRunning()
+            }
+        }
     }
 }

--- a/Gym-app-ioss/Views/NutritionView.swift
+++ b/Gym-app-ioss/Views/NutritionView.swift
@@ -27,6 +27,8 @@ struct NutritionView: View {
 
     @State var reload = true
     @State private var showScanner = false
+    @State private var showBarcodeError = false
+    @State private var barcodeErrorMessage = ""
     
     
     var body: some View {
@@ -185,6 +187,11 @@ struct NutritionView: View {
                                 showScanner = false
                             }
                         }
+                        .alert("Barcode Error", isPresented: $showBarcodeError) {
+                            Button("OK", role: .cancel) {}
+                        } message: {
+                            Text(barcodeErrorMessage)
+                        }
                     }
                 }
         else{
@@ -246,6 +253,11 @@ struct NutritionView: View {
                
                
                 
+            }
+            .alert("Barcode Error", isPresented: $showBarcodeError) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(barcodeErrorMessage)
             }
         }
     }
@@ -483,6 +495,8 @@ func handleBarcode(_ code: String) async {
         buttonPressed = false
     } catch {
         print("Barcode error: \(error)")
+        barcodeErrorMessage = error.localizedDescription
+        showBarcodeError = true
     }
 }
 }


### PR DESCRIPTION
## Summary
- run AVCaptureSession start/stop on a userInitiated background queue
- show an alert when a barcode lookup fails

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6846297c1148832b88cbee99122f5f99