### PR TITLE
Fix barcode nutrition handling

### DIFF
--- a/Gym-app-ioss/Model/BarcodeService.swift
+++ b/Gym-app-ioss/Model/BarcodeService.swift
@@ -10,16 +10,24 @@ struct ProductInfo: Codable {
 }
 
 struct Nutriments: Codable {
-    let energy_kcal: Double?
-    let proteins: Double?
-    let carbohydrates: Double?
-    let sugars: Double?
+    let energyKcalServing: Double?
+    let energyKcal100g: Double?
+    let proteinsServing: Double?
+    let proteins100g: Double?
+    let carbohydratesServing: Double?
+    let carbohydrates100g: Double?
+    let sugarsServing: Double?
+    let sugars100g: Double?
 
     enum CodingKeys: String, CodingKey {
-        case energy_kcal = "energy-kcal_100g"
-        case proteins = "proteins_100g"
-        case carbohydrates = "carbohydrates_100g"
-        case sugars = "sugars_100g"
+        case energyKcalServing = "energy-kcal_serving"
+        case energyKcal100g = "energy-kcal_100g"
+        case proteinsServing = "proteins_serving"
+        case proteins100g = "proteins_100g"
+        case carbohydratesServing = "carbohydrates_serving"
+        case carbohydrates100g = "carbohydrates_100g"
+        case sugarsServing = "sugars_serving"
+        case sugars100g = "sugars_100g"
     }
 }
 
@@ -39,10 +47,10 @@ class BarcodeService {
         guard let product = result.product else { throw BarcodeServiceError.productNotFound }
         let name = product.product_name ?? "Unknown"
         let nutriments = product.nutriments
-        let calories = Int(nutriments?.energy_kcal ?? 0)
-        let protein = Int(nutriments?.proteins ?? 0)
-        let carbs = Int(nutriments?.carbohydrates ?? 0)
-        let sugars = Int(nutriments?.sugars ?? 0)
+        let calories = Int(nutriments?.energyKcalServing ?? nutriments?.energyKcal100g ?? 0)
+        let protein = Int(nutriments?.proteinsServing ?? nutriments?.proteins100g ?? 0)
+        let carbs = Int(nutriments?.carbohydratesServing ?? nutriments?.carbohydrates100g ?? 0)
+        let sugars = Int(nutriments?.sugarsServing ?? nutriments?.sugars100g ?? 0)
         return Food(Name: name, Calories: calories, Sugars: sugars, Carbohydrates: carbs, Protein: protein)
     }
 }

--- a/Gym-app-ioss/Views/BarcodeScannerView.swift
+++ b/Gym-app-ioss/Views/BarcodeScannerView.swift
@@ -52,11 +52,17 @@ class ScannerViewController: UIViewController {
         previewLayer.frame = view.layer.bounds
         previewLayer.videoGravity = .resizeAspectFill
         view.layer.addSublayer(previewLayer)
-        captureSession.startRunning()
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.captureSession.startRunning()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        if captureSession?.isRunning == true { captureSession.stopRunning() }
+        if captureSession?.isRunning == true {
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                self?.captureSession.stopRunning()
+            }
+        }
     }
 }

--- a/Gym-app-ioss/Views/NutritionView.swift
+++ b/Gym-app-ioss/Views/NutritionView.swift
@@ -27,6 +27,8 @@ struct NutritionView: View {
 
     @State var reload = true
     @State private var showScanner = false
+    @State private var showBarcodeError = false
+    @State private var barcodeErrorMessage = ""
     
     
     var body: some View {
@@ -185,6 +187,11 @@ struct NutritionView: View {
                                 showScanner = false
                             }
                         }
+                        .alert("Barcode Error", isPresented: $showBarcodeError) {
+                            Button("OK", role: .cancel) {}
+                        } message: {
+                            Text(barcodeErrorMessage)
+                        }
                     }
                 }
         else{
@@ -247,17 +254,32 @@ struct NutritionView: View {
                
                 
             }
+            .alert("Barcode Error", isPresented: $showBarcodeError) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(barcodeErrorMessage)
+            }
         }
     }
   
   
     private func addItem() {
-            guard !newItemName.isEmpty else { return }
-        
-            items.append(tempFood ?? Food(Name: "failed", Calories: 1, Sugars: 1, Carbohydrates: 1, Protein: 1))
-            persistenceManager.saveItems(items: items)
-            
-        }
+        guard let food = tempFood else { return }
+
+        items.append(food)
+        persistenceManager.saveItems(items: items)
+
+        viewModel.items.append(
+            ExcListItem(
+                title: food.Name,
+                description: "This food with this portion has approx: \(food.Calories) calories, \(food.Protein)g of protein, \(food.Carbohydrates) Carbs, \(food.Sugars)g of sugars",
+                totalCalories: 0,
+                duration: 0,
+                NumExcersises: 0
+            )
+        )
+
+    }
      func deleteItems(at offsets: IndexSet) {
             items.remove(atOffsets: offsets)
          if HealthManager.shared.calories < 0{
@@ -483,6 +505,8 @@ func handleBarcode(_ code: String) async {
         buttonPressed = false
     } catch {
         print("Barcode error: \(error)")
+        barcodeErrorMessage = error.localizedDescription
+        showBarcodeError = true
     }
 }
 }


### PR DESCRIPTION
## Summary
- parse serving-based nutrient fields when available in `BarcodeService`
- append scanned items to the view model list

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6846297c1148832b88cbee99122f5f99