### PR TITLE
Remove embedded API key

### DIFF
--- a/Gym-app-ioss.xcodeproj/xcshareddata/xcschemes/Gym-app-ioss.xcscheme
+++ b/Gym-app-ioss.xcodeproj/xcshareddata/xcschemes/Gym-app-ioss.xcscheme
@@ -52,8 +52,8 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "API_KEY=&quot;AIzaSyD_X7ymdkDp0goekMxVfD3lOsO1yTGSgkU&quot;"
-            isEnabled = "YES">
+            argument = "API_KEY="
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = ""
@@ -63,8 +63,8 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "API_KEY"
-            value = "AIzaSyD_X7ymdkDp0goekMxVfD3lOsO1yTGSgkU"
-            isEnabled = "YES">
+            value = ""
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/Gym-app-ioss/GenerativeAi-Info.plist
+++ b/Gym-app-ioss/GenerativeAi-Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Api-Key</key>
-	<string>AIzaSyD_X7ymdkDp0goekMxVfD3lOsO1yTGSgkU</string>
+        <key>Api-Key</key>
+        <string></string>
 </dict>
 </plist>

--- a/Gym-app-ioss/Model/Gemini.swift
+++ b/Gym-app-ioss/Model/Gemini.swift
@@ -11,22 +11,12 @@ import GoogleGenerativeAI
 
 
 enum APIKey {
-  /// Fetch the API key from `GenerativeAI-Info.plist`
-  /// This is just *one* way how you can retrieve the API key for your app.
+  /// Retrieve the API key from an environment variable.
+  /// Set `GENERATIVEAI_API_KEY` in your environment at runtime.
   static var `default`: String {
-    guard let filePath = Bundle.main.path(forResource: "GenerativeAi-Info", ofType: "plist")
-    else {
-      fatalError("Couldn't find file 'GenerativeAI-Info.plist'.")
+    if let key = ProcessInfo.processInfo.environment["GENERATIVEAI_API_KEY"], !key.isEmpty {
+      return key
     }
-    let plist = NSDictionary(contentsOfFile: filePath)
-    guard let value = plist?.object(forKey: "Api-Key") as? String else {
-      fatalError("Couldn't find key 'API_KEY' in 'GenerativeAI-Info.plist'.")
-    }
-    if value.starts(with: "_") || value.isEmpty {
-      fatalError(
-        "Follow the instructions at https://ai.google.dev/tutorials/setup to get an API key."
-      )
-    }
-    return value
+    fatalError("Environment variable 'GENERATIVEAI_API_KEY' not set.")
   }
 }

--- a/Gym-app-ioss/Views/NutritionView.swift
+++ b/Gym-app-ioss/Views/NutritionView.swift
@@ -390,8 +390,8 @@ func geminii() async throws {
     )
 
     
-    // Don't check your API key into source control!
-    let apiKey = "AIzaSyD_X7ymdkDp0goekMxVfD3lOsO1yTGSgkU"
+    // Retrieve API key from secure storage
+    let apiKey = APIKey.default
     
     
     let model = GenerativeModel(

--- a/Gym-app-ioss/Views/finalData.swift
+++ b/Gym-app-ioss/Views/finalData.swift
@@ -221,8 +221,9 @@ struct finalData: View {
             responseMIMEType: "text/plain"
         )
         
-        // Don't check your API key into source control!
-        let apiKey = "AIzaSyD_X7ymdkDp0goekMxVfD3lOsO1yTGSgkU"
+
+        // Retrieve API key from secure storage
+        let apiKey = APIKey.default
         
         
        

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ PowAI is a Swift-based iOS fitness application that uses generative AI to build 
 - **Daily goal tracking** for calories and macronutrients.
 
 ## Getting Started
-1. Build and run on an iOS device or simulator.
-2. Sign up with your email, set your goals and start training!
+1. Set the `GENERATIVEAI_API_KEY` environment variable with your API key before launching the app.
+2. Build and run on an iOS device or simulator.
+3. Sign up with your email, set your goals and start training!
 
 ## Workouts
 After logging in your personalized routine is displayed on the main screen. Selecting a workout shows each exercise with sets, reps and estimated calories. Begin the session to activate the Live Activity timer and track your progress.


### PR DESCRIPTION
## Summary
- fetch AI key from `GENERATIVEAI_API_KEY` environment variable
- remove hard coded key from workout and nutrition views
- blank `GenerativeAi-Info.plist`
- clean xcscheme configuration
- document the new environment variable

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535a3ad9bc832bb3f5fe277b0bd4cd